### PR TITLE
Inline Latex Parsing

### DIFF
--- a/src/commonmark-react-renderer.js
+++ b/src/commonmark-react-renderer.js
@@ -105,7 +105,6 @@ var defaultRenderers = {
         return createElement('span', newProps, props.children);
     },
     latex_inline: function LatexInline(props) {
-        console.log('react renderer props', props);
         var newProps = getCoreProps(props);
         if (props.latexCode) {
             props['data-latex-code'] = props.latexCode;
@@ -281,8 +280,6 @@ function getNodeProps(node, key, opts, renderer, context) {
             break;
         case 'latex_inline':
             props.latexCode = node.latexCode;
-            console.log('node: ', node);
-            console.log('props: ', props);
             break;
         case 'paragraph':
             props.first = !(node._prev && node._prev.type === 'paragraph');


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A brief description of what this pull request does.
-->
Added rendering of latex code block with the react-native-math-view library. Latex code is split up in different lines and these are rendered independently. By default the code block displays 2 lines of latex code. If you click on the block the next screen will display all the code in a horizontal and vertical scroll view.

This is a PR for the commonmark-react-renderer library that i updated in order to parse the inline latex. The main PR can be found here: https://github.com/mattermost/mattermost-mobile/pull/5651

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket or fixes a reported issue, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-mobile/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
There is no ticket for this pull request.

#### Checklist
<!--
Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.
-->
- [x] Added or updated unit tests (required for all new features)
- [x] Has UI changes
- [ ] Includes text changes and localization file updates

#### Device Information
This PR was tested on: 
- Pixel 5: Android studio emulator
- OnePlus Nord 2 5G: Oxygen OS V11.3
- Iphone 12: Xcode emulator

#### Screenshots
<!--
If the PR includes UI changes, include screenshots/GIFs/Videos (for both iOS and Android if possible).
-->
<p float="left">
<img src="https://user-images.githubusercontent.com/55985776/131311854-235547e8-b2df-4559-902e-6acc7233879e.jpg" width=350>
<img src="https://user-images.githubusercontent.com/55985776/131311861-690661f0-ebe3-4dd2-aaed-0cf47ac86bac.jpg" width=350>
</p>
<p float="left">
<img src="https://user-images.githubusercontent.com/55985776/131311865-a18e809d-4dcd-47b0-9b96-9821c913632c.jpg" width=350>
<img src="https://user-images.githubusercontent.com/55985776/131311875-c9e42bcc-b2fc-4faf-9f10-156011d84d79.png" width=350>
</p>
<p float="left">
<img src="https://user-images.githubusercontent.com/55985776/131311895-3aafb384-906b-4c2c-ac4e-1a995ea984f7.png" width=350>
<img src="https://user-images.githubusercontent.com/55985776/131311900-705123fb-d3a9-4a03-8e9a-220c2f3eb66c.png" width=350>
</p>



#### Release Note
<!--
Add a release note for each of the following conditions:

* New features and improvements, including behavioural changes, UI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Example:

```release-note
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```release-note
NONE
```
-->

```release-note
Added rendering of latex code blocks. Added latex screen.
```
