### PR TITLE
Fix LaTex rendering and max nodes warning

### DIFF
--- a/src/commonmark-react-renderer.js
+++ b/src/commonmark-react-renderer.js
@@ -6,6 +6,7 @@ var isPlainObject = require('lodash.isplainobject');
 var xssFilters = require('xss-filters');
 var pascalCase = require('pascalcase');
 
+// Caution: type aliases must be lowercased, see 'normalizeTypeName'
 var typeAliases = {
     blockquote: 'block_quote',
     thematicbreak: 'thematic_break',
@@ -16,10 +17,10 @@ var typeAliases = {
     atmention: 'at_mention',
     channellink: 'channel_link',
     editedindicator: 'edited_indicator',
-    tableRow: 'table_row',
-    tableCell: 'table_cell',
-    latexInline: 'latex_inline',
-    maxNodesWarning: 'max_nodes_warning'
+    tablerow: 'table_row',
+    tablecell: 'table_cell',
+    latexinline: 'latex_inline',
+    maxnodeswarning: 'max_nodes_warning'
 };
 
 var defaultRenderers = {


### PR DESCRIPTION
#### Summary
The rendering of LaTex in messages is currently broken. 
In channels, LaTex is simply not showing up. In "Threads", the app crashes when a thread contains LaTex. 

The warning for messages with too many nodes is also not showing up.

The error is caused by false naming of type aliases. Due to the code design, the keys of type aliases have to be lowercased. 

#### Screenshots
|  before  |  after  |
|----|----|
| <img width="311" alt="Screenshot 2023-10-24 at 22 58 50" src="https://github.com/mattermost/commonmark-react-renderer/assets/17082165/873352ae-0728-4e77-a22e-40ed2ef85424"> | <img width="321" alt="Screenshot 2023-10-24 at 22 59 50" src="https://github.com/mattermost/commonmark-react-renderer/assets/17082165/45c5ecbf-b528-4255-80ad-96b661e9f7b7"> 
| <img width="311" alt="Screenshot 2023-10-24 at 22 58 25" src="https://github.com/mattermost/commonmark-react-renderer/assets/17082165/a035e55a-9aee-488d-aead-ab862902282b"> | <img width="312" alt="Screenshot 2023-10-24 at 22 58 35" src="https://github.com/mattermost/commonmark-react-renderer/assets/17082165/c4b4935e-8daa-4ee1-bb2b-80f66f750e04"> 
| <img width="313" alt="Screenshot 2023-10-24 at 22 54 41" src="https://github.com/mattermost/commonmark-react-renderer/assets/17082165/0b5311e0-9810-48ce-879c-24ec22d0844b"> | <img width="316" alt="Screenshot 2023-10-24 at 22 54 59" src="https://github.com/mattermost/commonmark-react-renderer/assets/17082165/0615608b-b1a1-4e29-9687-72893f77eebe"> |

#### Ticket Link
Closes https://github.com/mattermost/mattermost/issues/24982

